### PR TITLE
Fix display bug while setting up in table

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,8 @@ Some features that might be useful. If you feel up to contributing then these co
 
 - Debug display issues with scrolling/collapsing tree during steup. This probably because the height of the table decreases and then the
   tallest area is "orphaned". I probably have to have a constant wosrt case padding at the bottom of the table, wich would be 12 lines?
-
+- Refactor release process to delay the release creation until the last step. There is a period now where the copy/paste install fails
+  because the new release binaries haven't been uploaded to the release yet.
 - Timeouts for the installs
 - Global variables. This would probably look just like make variables.
 - Windows support. For all I know it already works, but I don't use Windows. It would be good to get a binary building for Windows users.

--- a/booty/app.py
+++ b/booty/app.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Literal
 
 from rich.box import SIMPLE
 from rich.text import Text
+from rich.padding import Padding
 from rich.table import Table
 from rich.console import Group
 from rich.live import Live
@@ -86,7 +87,7 @@ class App:
 
         if sudo_targets:
             # run sudo -v to make sure the user has sudo access
-            targets = ", ".join(sudo_targets)
+            targets = ", ".join(set(sudo_targets))
             print(
                 f"""
 Detected sudo in targets: '{targets}'.
@@ -181,12 +182,16 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
         overall_progress = Progress()
         overall_id = overall_progress.add_task("Status", total=len(missing_packages))
 
-        group = Group(table, overall_progress)
+        # table_padding = Text("\n" * (len(missing_packages) + 1))
+
+        max_padding = 0
+        padding = Padding(table, (0, 0, 0, 0))
+        group = Group(padding, overall_progress)
 
         total_time = 0.0
         status_result = StatusResult()
         gen = self.data.G.bfs()
-        with Live(group, refresh_per_second=_REFRESH_RATE):
+        with Live() as live:
             try:
                 next(gen)  # Skip the first fake target
                 target = gen.send(True)
@@ -210,6 +215,9 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
                         time_text.plain = f"{time.perf_counter() - start_time:.2f}s"
                         tree.set_stdout(cmd.latest_stdout())
                         tree.set_stderr(cmd.latest_stderr())
+                        max_padding = max(max_padding, tree.height())
+                        padding.bottom = abs(max_padding - tree.height())
+                        live.update(group)
 
                     cmd_time = time.perf_counter() - start_time
                     time_text.plain = f"{cmd_time:.2f}s"
@@ -219,6 +227,8 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
                         status_result.installed.append(target)
                         status_text.plain = "🟢 Installed"
                         tree.reset()
+                        padding.bottom = abs(max_padding - tree.height())
+                        live.update(group)
 
                     else:
                         status_text.plain = "🔴 Error"
@@ -227,6 +237,7 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
 
                     target = gen.send(cmd.code == 0)
                     overall_progress.advance(overall_id)
+                    live.update(group)
 
             except StopIteration as e:
                 skipped: List[str] = e.value

--- a/booty/app.py
+++ b/booty/app.py
@@ -106,10 +106,9 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
         }
 
         table = Table(title="Target Status", show_header=True, show_edge=False, title_style="bold", box=SIMPLE)
-
         table.add_column("Target", no_wrap=True, width=20)
-        table.add_column("Dependencies", width=20)
-        table.add_column("Status", width=20)
+        table.add_column("Dependencies", width=20, no_wrap=True)
+        table.add_column("Status", width=20, no_wrap=True)
         table.add_column("Details", width=70, no_wrap=True)
         table.add_column("Time", justify="right", width=10)
 
@@ -174,9 +173,9 @@ Running `sudo -v` to cache sudo credentials. You can disable this behavior with 
 
         table = Table(title="Setup Status", show_header=True, show_edge=False, title_style="bold", box=SIMPLE)
         table.add_column("Target", no_wrap=True, width=20)
-        table.add_column("Status", width=20)
+        table.add_column("Status", width=20, no_wrap=True)
         table.add_column("Details", width=93, no_wrap=True)
-        table.add_column("Time", justify="right", width=10)
+        table.add_column("Time", justify="right", width=10, no_wrap=True)
 
         missing_packages = set([*status_result.missing, *status_result.errors])
         overall_progress = Progress()

--- a/booty/execute.py
+++ b/booty/execute.py
@@ -145,8 +145,8 @@ class CommandExecutor:
     def all_stderr(self) -> str:
         return "\n".join(self.stderr)
 
-    def latest_stdout(self, tail_n: int = 5) -> str:
-        return "\n".join(self.stdout[-tail_n:])
+    def latest_stdout(self, tail_n: int = 5) -> List[str]:
+        return self.stdout[-tail_n:]
 
-    def latest_stderr(self, tail_n: int = 5) -> str:
-        return "\n".join(self.stderr[-tail_n:])
+    def latest_stderr(self, tail_n: int = 5) -> List[str]:
+        return self.stderr[-tail_n:]

--- a/booty/ui.py
+++ b/booty/ui.py
@@ -1,11 +1,18 @@
-from typing import Optional
+from typing import List, Optional
+from rich.console import Group
+from rich.live import Live
+from rich.progress import Progress
+from rich.padding import Padding
+from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
 
 class StdTree:
     _stdout_text: Optional[Text]
+    _stdout_str: List[str]
     _stderr_text: Optional[Text]
+    _stderr_str: List[str]
 
     def __init__(self, cmd: str) -> None:
         self.tree = Tree("", hide_root=True)
@@ -13,8 +20,10 @@ class StdTree:
         self.tree.add(cmd)
         self._stdout_text = None
         self._stderr_text = None
+        self._stdout_str = []
+        self._stderr_str = []
 
-    def set_stdout(self, stdout: str):
+    def set_stdout(self, stdout: List[str]):
         if not stdout:
             return
 
@@ -23,9 +32,14 @@ class StdTree:
             stdout_branch = self.tree.add("stdout")
             stdout_branch.add(self._stdout_text)
 
-        self._stdout_text.plain = stdout
+            if self._stderr_text:
+                # Swap the children so that stdout is always first
+                self.tree.children = [self.tree.children[1], self.tree.children[0]]
 
-    def set_stderr(self, stderr: str):
+        self._stdout_str = stdout
+        self._stdout_text.plain = "\n".join(stdout)
+
+    def set_stderr(self, stderr: List[str]):
         if not stderr:
             return
 
@@ -33,11 +47,41 @@ class StdTree:
             self._stderr_text = Text("", style="red")
             stderr_branch = self.tree.add("stderr")
             stderr_branch.add(self._stderr_text)
+            self._stderr_str = stderr
 
-        self._stderr_text.plain = stderr
+        self._stderr_str = stderr
+        self._stderr_text.plain = "\n".join(stderr)
 
     def reset(self):
         self._stdout_text = None
         self._stderr_text = None
+        self._stdout_str = []
+        self._stderr_str = []
         self.tree.children = []
         self.tree.add(self.cmd)
+
+    def height(self) -> int:
+        stdout_height = len(self._stdout_str) + 1 if self._stdout_str else 0
+        stderr_height = len(self._stderr_str) + 1 if self._stderr_str else 0
+        cmd_height = 1
+
+        return cmd_height + stdout_height + stderr_height
+
+
+class PaddedTable:
+    def __init__(self, table: Table, total: int) -> None:
+        self.table = table
+        self._progress = Progress()
+        # self.progress_id = progress.add_task("Status", total=total)
+        self._max_padding = 0
+        self._padding = Padding(table, (0, 0, 0, 0))
+        self._group = Group(self._padding, self._progress)
+
+    # def get_std_tree(self, cmd: str) -> StdTree:
+    # self.std_tree = StdTree(self._display_setup(self.data.execution_index[target]))
+
+    def update(self, live: Live) -> None:
+        pass
+
+        # self._padding.bottom = abs(self._max_padding - self.std_tree.height())
+        # live.update(group)

--- a/examples/always_reinstalls.booty
+++ b/examples/always_reinstalls.booty
@@ -51,7 +51,30 @@ always_fail:
         echo "This is a stderr message" 1>&2
         false
 
+
+stderr_first -> m
+stderr_first:
+    setup:
+        sleep .1
+        echo "This is an error message" 1>&2
+        false
+    is_setup:
+        sleep .1
+        echo "This is a stderr message" 1>&2
+        echo "This is a stdout message"
+        false
+
 skip1: always_install()
 skip2: always_install()
 skip3: always_install()
 skip4: always_install()
+
+skip1: always_install()
+skip2: always_install()
+skip3: always_install()
+skip4: always_install()
+
+a2 -> m
+a2:
+    setup: sudo apt-get update
+    is_setup:always_install()


### PR DESCRIPTION
The table used to leave behind artifacts during the setup process. I think this happened because the table would grow and then shrink in height, leaving behind w/e was at the top most portion of the table. This change adds some dynamic padding to the table so it never shrinks in height, but also doesn't pre-reserve the max padding in case none of the targets cause the table to grow.