### PR TITLE
Fix bug with recipes that call other recipes

### DIFF
--- a/booty/app.py
+++ b/booty/app.py
@@ -23,9 +23,6 @@ from booty.ui import Padder, StdTree
 from booty.validation import validate
 
 
-_REFRESH_RATE = 8
-
-
 @dataclass
 class StatusResult:
     missing: List[str] = field(default_factory=list)

--- a/examples/always_reinstalls.booty
+++ b/examples/always_reinstalls.booty
@@ -1,4 +1,17 @@
 
+recipe first():
+    setup: sleep .1
+    is_setup:
+        sleep .1
+        false
+
+recipe calls_first():
+    setup: first()
+    is_setup: first()
+
+
+first_target: calls_first()
+
 recipe always_install():
     setup: sleep .1
     is_setup:

--- a/examples/install.booty
+++ b/examples/install.booty
@@ -155,3 +155,22 @@ frog:
     setup: raco pkg install --auto frog
     is_setup: raco pkg show frog | grep Package
 
+
+
+
+##
+## Silly test cases that aren't real
+##
+recipe first():
+    setup: sleep .1
+    is_setup:
+        sleep .1
+        false
+
+# recipe that calls another recipe
+recipe calls_first():
+    setup: first()
+    is_setup: first()
+
+
+first_target: calls_first()


### PR DESCRIPTION
I didn't have any examples of recipes calling other recipes, which was the only way that the path that had the old execute logic would happen. Now there's only a single way to execute things and commands properly flow through from nested recipes.